### PR TITLE
Chuck Norris: use '-pie' for linking only

### DIFF
--- a/content/en/post/0073-let-s-build-chuck-norris-part-6-android-cross-compilation.md
+++ b/content/en/post/0073-let-s-build-chuck-norris-part-6-android-cross-compilation.md
@@ -133,7 +133,7 @@ ${NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin/clang
   --gcc-toolchain=${NDK_ROOT}/toolchains/x86_64-4.9/prebuilt/linux-x86_64
   --sysroot=${NDK_ROOT}/sysroot
   -isystem ${NDK_ROOT}/sysroot/usr/include/x86_64-linux-android
-  -pie -o  hello.c.o -c hello.c
+  -o  hello.c.o -c hello.c
 
 ${NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin/clang
   --target=x86_64-none-linux-android
@@ -167,7 +167,6 @@ ${NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin/clang
   --gcc-toolchain=${NDK_ROOT}/toolchains/arm-linux-androideabi-4.9/...
   --sysroot=${NDK_ROOT}/sysroot
   -isystem ${NDK_ROOT}/sysroot/usr/include/arm-linux-androideabi
-  -pie
   -o  hello.c.o -c hello.c
 
 ${NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin/clang


### PR DESCRIPTION
When using -pie for compiling .c to .o files, clang will warn:

    clang: warning: argument unused during compilation: '-pie'
    [-Wunused-command-line-argument]

As I understand, -pie need to be specified only when building the acutal executable or the shared library file